### PR TITLE
fix: update entry file for development config

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -7,7 +7,7 @@ const merge = require('webpack-merge')
 const baseWebpackConfig = require('./webpack.core')
 
 const developmentConfig = merge.smart(baseWebpackConfig, {
-  entry: './src/example/index.jsx',
+  entry: './src/example/index.tsx',
 
   mode: 'development',
 


### PR DESCRIPTION
fix #124

### Description

This PR fixes the error described on #124 issue. Basically, the error is thrown because `webpack` looks for an entry file that doesn't exist anymore (`./src/example/index.jsx`), since the code was rewritten to use `tsx` instead of `jsx`. 

### Review

- [x] Verify that all classes affected by the changes have **good** top-level documentation.
- [ ] Verify that new code has been covered with specs (and features if applicable).
- [ ] Verify that a corresponding meaningful changelog entry has been added (`* Add Github pull request template`), for this change if applicable.
- [ ] Test manually.
- [ ] Get two :+1: from code review.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that all new dependencies are included in `package.json`.
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
- [ ] Verify the branch name starts with `NNNN` where `NNNN` is the issue number.