### PR TITLE
Support month names locale (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ All of the properties are optional, just rendering `<Calendar />` will already g
 | `selected`             |                                              | selected dates. Can be ether single `Date` object if `mode` is `single`, or object `{start: Date(), end: Date()}` if `mode` is `range`                                                                                                                                                                     |
 | `today`                | `datePropType`\*                             | current date (useful when you want to show current date in different time zone). Default is `new Date()` selects a date (in `single` mode) or a dates range (`range` mode) selection. Works only in the `range` mode. When the function is passed then automatic range selection handing will be disabled. |
 | `weekStartsOn`         | `number`                                     | the index of the first day of the week (0 - Sunday). Default is 0                                                                                                                                                                                                                                          |
+`locale` |  `string` | locale for month names. See [date-fns locales](https://github.com/date-fns/date-fns/blob/master/src/locale/index.js) for available options. Defaults to 'en'.
 
 `datePropType` - `number`, `string` or `instanceOf(Date)`
 

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -78,6 +78,7 @@ export type Props = {
   selected?: IDate | ISelectionRange
   today?: IDate
   weekStartsOn?: number
+  locale?: string
 }
 
 type State = {
@@ -96,7 +97,8 @@ export default class Calendar extends Component<Props, State> {
     headerNextTitle: NEXT_MONTH_TITLE,
     headerPrevTitle: PREV_MONTH_TITLE,
     mode: 'single',
-    weekStartsOn: 1
+    weekStartsOn: 1,
+    locale: 'en'
   }
 
   constructor(props: Props) {
@@ -315,7 +317,8 @@ export default class Calendar extends Component<Props, State> {
       maxDate,
       minDate,
       MonthHeaderComponent = MonthHeader,
-      renderMonthHeader
+      renderMonthHeader,
+      locale
     } = this.props
 
     return (
@@ -330,6 +333,7 @@ export default class Calendar extends Component<Props, State> {
         headerPrevTitle={headerPrevTitle}
         maxDate={maxDate}
         minDate={minDate}
+        locale={locale}
         onMonthChange={this._switchMonth.bind(this)}
       />
     )

--- a/src/calendar/month_header.tsx
+++ b/src/calendar/month_header.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ReactElement } from 'react'
 import addMonths from 'date-fns/add_months'
-import formatDate from 'date-fns/format'
+import format from 'date-fns/format'
 import isAfter from 'date-fns/is_after'
 import isBefore from 'date-fns/is_before'
 import startOfMonth from 'date-fns/start_of_month'
@@ -18,12 +18,33 @@ export type Props = {
   headerPrevTitle?: string
   maxDate?: IDate
   minDate?: IDate
+  locale?: string
   onMonthChange: (...args: any[]) => any
+}
+
+export type State = {
+  localeModule: any
 }
 
 // TODO: FC Rewrite
 /* eslint-disable react/require-optimization */
-export default class MonthHeader extends Component<Props, {}> {
+export default class MonthHeader extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      localeModule: null
+    }
+  }
+
+  componentDidMount() {
+    import(`date-fns/locale/${this.props.locale}`)
+      .then(localeModule => this.setState({ localeModule }))
+      .catch(err => {
+        import('date-fns/locale/en')
+          .then(localeModule => this.setState({ localeModule }))
+      });
+  }
+
   _switchMonth(offset: -1 | 1) {
     const { onMonthChange, activeMonth } = this.props
 
@@ -42,6 +63,8 @@ export default class MonthHeader extends Component<Props, {}> {
       headerPrevTitle,
       customRender
     } = this.props
+
+    const { localeModule } = this.state;
 
     const prevEnabled = minDate
       ? isBefore(startOfMonth(minDate), startOfMonth(activeMonth))
@@ -72,7 +95,7 @@ export default class MonthHeader extends Component<Props, {}> {
           blockClassName={blockClassName}
         />
         <div className={`${blockClassName}-month_header_title`}>
-          {formatDate(activeMonth, 'MMMM YYYY')}
+          { localeModule && format(activeMonth, 'MMMM YYYY', { locale: localeModule })}
         </div>
         <HeaderButton
           type='next'


### PR DESCRIPTION
### Description

- Formats the month name based on the specified locale. 
- Resolve `date-fns` locale module by the `locale` prop. 
- It defaults to `en` either if by default prop value or by wrong locale name.

### Review

- [x] Verify that all classes affected by the changes have **good** top-level documentation.
- [ ] Verify that new code has been covered with specs (and features if applicable).
- [ ] Verify that a corresponding meaningful changelog entry has been added (`* Add Github pull request template`), for this change if applicable.
- [ ] Test manually.
- [ ] Get two :+1: from code review.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that all new dependencies are included in `package.json`.
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
- [ ] Verify the branch name starts with `NNNN` where `NNNN` is the issue number.