### PR TITLE
fix: change minDate to start at the beginning of the day

### DIFF
--- a/src/calendar/__specs__/calendar_spec.tsx
+++ b/src/calendar/__specs__/calendar_spec.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactTestRenderer from 'react-test-renderer'
 
 import Calendar from '../calendar'
+import Month from '../month'
 
 describe('Calendar', () => {
   let instance, props, wrapper
@@ -229,7 +230,7 @@ describe('Calendar', () => {
 
       describe('when prop `onSelectionProgress` is defined', () => {
         it('returns prop `selected.start`', () => {
-          props = { mode: 'range', onSelectionProgress: () => {}, selected }
+          props = { mode: 'range', onSelectionProgress: () => { }, selected }
           wrapper = shallow(<Calendar {...props} />)
           wrapper.setState({ selection })
 
@@ -354,10 +355,21 @@ describe('Calendar', () => {
   describe('#render', () => {
     it('renders <Calendar />', () => {
       const tree = ReactTestRenderer.create(
-        <Calendar activeMonth={date} onMonthChange={() => {}} />
+        <Calendar activeMonth={date} onMonthChange={() => { }} />
       ).toJSON()
 
       expect(tree).toMatchSnapshot()
     })
+  })
+
+  it('uses normalized minDate with a start at 00:00', () => {
+    const dirtyMinDate = '2020-09-03T11:26:49.526Z'
+    const { root } = ReactTestRenderer.create(
+      <Calendar minDate={dirtyMinDate} activeMonth={date} onMonthChange={() => { }} />
+    )
+
+    const startOfMinDate = new Date(2020, 8, 3) // start of the day in local time - 00:00
+
+    expect(root.findByType(Month).props.minDate).toEqual(startOfMinDate)
   })
 })

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ComponentProps, ReactElement } from 'react'
 import isSameMonth from 'date-fns/is_same_month'
 import isValidDate from 'date-fns/is_valid'
+import startOfDay from 'date-fns/start_of_day'
 import startOfMonth from 'date-fns/start_of_month'
 
 import * as helper from '../helper'
@@ -278,6 +279,8 @@ export default class Calendar extends Component<Props, State> {
     const selection = this._selection()
     const highlight = this._highlight()
 
+    const normalizedMinDate = minDate ? startOfDay(minDate) : minDate
+
     return (
       // @ts-ignore: No overload matches this call
       <Month
@@ -295,7 +298,7 @@ export default class Calendar extends Component<Props, State> {
         highlightedEnd={highlight.end}
         highlightedStart={highlight.start}
         maxDate={maxDate}
-        minDate={minDate}
+        minDate={normalizedMinDate}
         minNumberOfWeeks={minNumberOfWeeks}
         mode={mode as 'range' | 'single'}
         onChange={this._selectionChanged.bind(this)}

--- a/src/calendar/stories/index.jsx
+++ b/src/calendar/stories/index.jsx
@@ -58,7 +58,7 @@ stories
 
     // minDate
     const minDateLabel = 'minDate'
-    const minDateDefaultValue = new Date('2018-01-01')
+    const minDateDefaultValue = new Date('2018-01-02')
     const minDate = date(minDateLabel, minDateDefaultValue)
 
     // minNumberOfWeeks


### PR DESCRIPTION
### Description

Fix minDate - it should start at the beginning of the day to cover dates in local timezone.

Previously dates of the month started at `00:00` in local timezone, when minDate was created in local timezone, in UTC+3 it meant that minDate started only at `03:00` -> minDate was after a day that starts at `00:00` -> day can't be selected when it should have been selectable.

### Review

- [x] Verify that all classes affected by the changes have **good** top-level documentation.
- [ ] Verify that new code has been covered with specs (and features if applicable).
- [ ] Verify that a corresponding meaningful changelog entry has been added (`* Add Github pull request template`), for this change if applicable.
- [ ] Test manually.
- [ ] Get two :+1: from code review.

### Pre-merge checklist

- [ ] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [ ] Verify that all new dependencies are included in `package.json`.
- [ ] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).
- [ ] Squash related commits together.
- [ ] Verify the branch name starts with `NNNN` where `NNNN` is the issue number.

### Screenshots

| Before                                        | After                                         |
| --------------------------------------------- | --------------------------------------------- |
| _Insert screenshots and/or screen recordings_ | _Insert screenshots and/or screen recordings_ |

### Other

_Provide additional notes, remarks, links, mention specific people to review,…_
